### PR TITLE
Add UDID profile service scripts

### DIFF
--- a/get-udid.php
+++ b/get-udid.php
@@ -1,0 +1,65 @@
+<?php
+// get-udid.php
+// Outputs a signed mobile configuration profile to collect the device UDID
+
+$profile = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>PayloadContent</key>
+    <dict>
+        <key>URL</key>
+        <string>https://api.xlop.com/udid.php</string>
+        <key>DeviceAttributes</key>
+        <array>
+            <string>UDID</string>
+        </array>
+    </dict>
+    <key>PayloadOrganization</key>
+    <string>XLop</string>
+    <key>PayloadDisplayName</key>
+    <string>Get Device UDID</string>
+    <key>PayloadVersion</key>
+    <integer>1</integer>
+    <key>PayloadUUID</key>
+    <string>e4f726c7-9b72-4f28-8fcd-3ff257f4bdf4</string>
+    <key>PayloadIdentifier</key>
+    <string>com.xlop.profile.udid</string>
+    <key>PayloadDescription</key>
+    <string>Installs a profile service to obtain the device UDID</string>
+    <key>PayloadType</key>
+    <string>Profile Service</string>
+</dict>
+</plist>
+XML;
+
+$cert = 'file://path/to/certificate.pem'; // replace with actual certificate path
+$privkey = 'file://path/to/private.key'; // replace with actual private key path
+$passphrase = ''; // set passphrase if the private key is protected
+
+$tempIn = tempnam(sys_get_temp_dir(), 'profile');
+$tempOut = tempnam(sys_get_temp_dir(), 'signed');
+file_put_contents($tempIn, $profile);
+
+if (openssl_pkcs7_sign(
+        $tempIn,
+        $tempOut,
+        $cert,
+        [$privkey, $passphrase],
+        [],
+        PKCS7_BINARY | PKCS7_DETACHED
+    )) {
+    $signed = file_get_contents($tempOut);
+    $parts = explode("\n\n", $signed, 2);
+    $pkcs7 = $parts[1] ?? '';
+    header('Content-Type: application/x-apple-aspen-config');
+    header('Content-Disposition: attachment; filename="udid.mobileconfig"');
+    echo $pkcs7;
+} else {
+    http_response_code(500);
+    echo 'Failed to sign profile';
+}
+
+unlink($tempIn);
+unlink($tempOut);

--- a/udid.php
+++ b/udid.php
@@ -1,0 +1,50 @@
+<?php
+// udid.php
+// Receives signed POSTed profile response, extracts UDID and redirects to the front-end.
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || $_SERVER['CONTENT_TYPE'] !== 'application/pkcs7-signature') {
+    http_response_code(400);
+    echo 'Invalid request';
+    exit;
+}
+
+$payload = file_get_contents('php://input');
+$tempIn = tempnam(sys_get_temp_dir(), 'payload');
+file_put_contents($tempIn, $payload);
+
+// Use openssl to decode the PKCS#7 signature and obtain the embedded XML
+$cmd = 'openssl smime -inform DER -verify -noverify -in ' . escapeshellarg($tempIn);
+$xml = shell_exec($cmd);
+unlink($tempIn);
+
+if (!$xml) {
+    http_response_code(500);
+    echo 'Failed to decode payload';
+    exit;
+}
+
+// Parse the XML for the UDID value
+$udid = '';
+$doc = new DOMDocument();
+if (@$doc->loadXML($xml)) {
+    $keys = $doc->getElementsByTagName('key');
+    foreach ($keys as $key) {
+        if ($key->nodeValue === 'UDID') {
+            $node = $key->nextSibling;
+            while ($node && $node->nodeType !== XML_ELEMENT_NODE) {
+                $node = $node->nextSibling;
+            }
+            $udid = $node ? trim($node->nodeValue) : '';
+            break;
+        }
+    }
+}
+
+if ($udid) {
+    $frontend = 'https://xlop.com/'; // replace with your front-end domain
+    header('Location: ' . $frontend . '?udid=' . urlencode($udid));
+    exit;
+}
+
+http_response_code(500);
+echo 'UDID not found';


### PR DESCRIPTION
## Summary
- add `get-udid.php` to serve a signed profile that requests device UDID
- add `udid.php` to decode the profile response and redirect with the UDID

## Testing
- `php -l get-udid.php`
- `php -l udid.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1964eebec832498042f0fab605fb9