### PR TITLE
Point profile signer to server certificate paths

### DIFF
--- a/get-udid.php
+++ b/get-udid.php
@@ -34,8 +34,8 @@ $profile = <<<XML
 </plist>
 XML;
 
-$cert = 'file://path/to/certificate.pem'; // replace with actual certificate path
-$privkey = 'file://path/to/private.key'; // replace with actual private key path
+$cert = 'file:///etc/ssl/certs/api.bedpage.com.pem'; // replace with actual certificate path
+$privkey = 'file:///etc/ssl/private/api.bedpage.com.key'; // replace with actual private key path
 $passphrase = ''; // set passphrase if the private key is protected
 
 $tempIn = tempnam(sys_get_temp_dir(), 'profile');


### PR DESCRIPTION
## Summary
- Update `get-udid.php` to use the real certificate and private key locations on the server

## Testing
- `php -l get-udid.php`
- `php get-udid.php > /tmp/udid.mobileconfig`
- `ls -l /tmp/udid.mobileconfig`
- `head -n 5 /tmp/udid.mobileconfig`


------
https://chatgpt.com/codex/tasks/task_e_68a1a846086883248205e07481db8f11