### PR TITLE
feat(frontend): add shared config and gbox link

### DIFF
--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -1,0 +1,13 @@
+export const FRONT_URL = '';
+export const BACKEND_URL = '';
+export const PAY_LINK_CARD = '';
+export const PAY_LINK_APPLE = '';
+export const GBOX_BASE = '';
+
+export function gboxLink({ udid, token, redirect }) {
+  const params = new URLSearchParams();
+  if (udid) params.set('udid', udid);
+  if (token) params.set('token', token);
+  if (redirect) params.set('redirect', redirect);
+  return `${GBOX_BASE}?${params.toString()}`;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,10 @@
+import { BACKEND_URL } from './config.js';
+
 (function(){
+  // Set backend link for UDID profile
+  const udidLink=document.querySelector('#get-udid');
+  if(udidLink){ udidLink.href=`${BACKEND_URL}/profile.php`; }
+
   // Auto-fill UDID from query
   const p=new URLSearchParams(location.search);
   const udid=p.get('udid');

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Xlop Certificates</title>
-  <link rel="stylesheet" href="assets/css/style.css">
-  <script defer src="assets/js/main.js"></script>
+    <link rel="stylesheet" href="assets/css/style.css">
+    <script type="module" src="assets/js/main.js"></script>
   <meta name="description" content="شهادات توقيع iOS مع جلب UDID تلقائياً.">
 </head>
 <body>
@@ -26,8 +26,7 @@
     <h1>شهادات توقيع iOS — بسرعة وثقة</h1>
     <p>اضغط زر <strong>الحصول على UDID</strong> لتنزيل ملف تعريف مؤقت، ثبّته من الإعدادات، وبنرجّعك للصفحة ورقم جهازك جاهز تلقائيًا.</p>
     <div style="display:flex;gap:12px;justify-content:center;margin-top:12px">
-      <!-- TODO: غيّر PHP_BASE_URL بعد رفع الباك-إند -->
-      <a class="btn" id="get-udid" href="PHP_BASE_URL/profile.php">الحصول على UDID</a>
+      <a class="btn" id="get-udid" href="#">الحصول على UDID</a>
       <a class="btn outline" href="purchase.html">شراء الشهادة</a>
     </div>
     <p class="note">يُفضل فتح الموقع عبر Safari على iPhone.</p>


### PR DESCRIPTION
## Summary
- add config constants and gboxLink builder
- wire main script to use BACKEND_URL constant
- load main.js as ES module to access config

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68ab2b0ae0c083248bd2d6e794cf559b