### PR TITLE
feat(frontend): add quick payment form

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -27,4 +27,53 @@ import { BACKEND_URL } from './config.js';
       if(el){ e.preventDefault(); el.scrollIntoView({behavior:'smooth'}); }
     });
   });
+
+  // Quick purchase form
+  const form=document.getElementById('quick-form');
+  if(form){
+    const email=form.querySelector('#email');
+    const udidInput=form.querySelector('#udid');
+    const token=form.querySelector('#token');
+    const method=form.querySelector('#method');
+
+    [email, udidInput, token, method].forEach(el=>{
+      const v=localStorage.getItem(el.id);
+      if(v){ el.value=v; }
+    });
+
+    const validateEmail=()=>{
+      const v=email.value.trim();
+      email.setCustomValidity(/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)?'':'البريد غير صحيح');
+    };
+    const validateUdid=()=>{
+      const v=udidInput.value.trim();
+      udidInput.setCustomValidity(v.startsWith('000') && v.length===40 ? '' : 'UDID غير صالح');
+    };
+    const validateToken=()=>{
+      const v=token.value.trim();
+      token.setCustomValidity(v ? '' : 'الرمز مطلوب');
+    };
+
+    email.addEventListener('input', ()=>{ validateEmail(); localStorage.setItem('email', email.value); });
+    udidInput.addEventListener('input', ()=>{ validateUdid(); localStorage.setItem('udid', udidInput.value); });
+    token.addEventListener('input', ()=>{ validateToken(); localStorage.setItem('token', token.value); });
+    method.addEventListener('change', ()=>{ localStorage.setItem('method', method.value); });
+
+    form.addEventListener('submit', e=>{
+      e.preventDefault();
+      validateEmail();
+      validateUdid();
+      validateToken();
+      if(form.checkValidity()){
+        const params=new URLSearchParams({email:email.value.trim(), udid:udidInput.value.trim(), token:token.value.trim(), method:method.value});
+        localStorage.setItem('email', email.value);
+        localStorage.setItem('udid', udidInput.value);
+        localStorage.setItem('token', token.value);
+        localStorage.setItem('method', method.value);
+        location.href=`purchase.html?${params.toString()}`;
+      }else{
+        form.reportValidity();
+      }
+    });
+  }
 })();

--- a/index.html
+++ b/index.html
@@ -34,6 +34,24 @@
   </header>
 
   <section class="section container">
+    <h2>شراء سريع</h2>
+    <form id="quick-form" dir="rtl" style="max-width:400px;margin:auto">
+      <label for="email">البريد الإلكتروني</label>
+      <input class="input" type="email" id="email" required>
+      <label for="udid">UDID</label>
+      <input class="input" type="text" id="udid" required>
+      <label for="token">Token</label>
+      <input class="input" type="text" id="token" required>
+      <label for="method">طريقة الدفع</label>
+      <select class="input" id="method">
+        <option value="card">بطاقة</option>
+        <option value="apple">Apple</option>
+      </select>
+      <button type="submit" class="btn" style="margin-top:12px">ادفع الآن</button>
+    </form>
+  </section>
+
+  <section class="section container">
     <div class="grid">
       <div class="card">
         <h3>1) احصل على UDID</h3>


### PR DESCRIPTION
## Summary
- add RTL quick purchase form with email, UDID, token and payment method
- validate inputs in main.js and redirect to purchase page when valid
- persist last entered values in localStorage for support

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68ab2c1715ec8324af396d517242bcc8