### PR TITLE
Redirect to Paymob and add post-payment install link

### DIFF
--- a/purchase.html
+++ b/purchase.html
@@ -1,63 +1,28 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ar" dir="rtl">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>شراء الشهادة</title>
-    <style>
-        body {
-            background-color: black;
-            color: white;
-            font-family: Arial, sans-serif;
-            text-align: center;
-            padding: 20px;
-        }
-        input, select {
-            width: 90%;
-            padding: 10px;
-            margin: 10px 0;
-            border-radius: 5px;
-            border: none;
-            font-size: 16px;
-        }
-        #paypal-button-container {
-            margin-top: 20px;
-        }
-    </style>
-    <script src="https://www.paypal.com/sdk/js?client-id=Adnx8iybU3z3fd00LBR30xdswJtPD7FJA7ZMBO5s4VnZu0sp5KLNdJDklX7ol6cLF65LtQC8c7wpT_lo&currency=SAR"></script>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>جارٍ تحويلك…</title>
+  <style>
+    body{background:#000;color:#fff;font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;text-align:center;padding:40px}
+  </style>
 </head>
 <body>
-
-    <h1>شراء الشهادة</h1>
-    <input type="email" id="email" placeholder="example@email.com">
-    <input type="text" id="udid" placeholder="أدخل UDID الخاص بك">
-    <select id="plan">
-        <option value="99">سنتين – 99 رس</option>
-        <option value="59">سنة – 59 رس</option>
-    </select>
-
-    <div id="paypal-button-container"></div>
-
-    <script>
-        paypal.Buttons({
-            createOrder: function(data, actions) {
-                let price = document.getElementById("plan").value;
-                return actions.order.create({
-                    purchase_units: [{
-                        amount: {
-                            value: price,
-                            currency_code: "SAR"
-                        }
-                    }]
-                });
-            },
-            onApprove: function(data, actions) {
-                return actions.order.capture().then(function(details) {
-                    alert('تم الدفع بنجاح بواسطة: ' + details.payer.name.given_name);
-                });
-            }
-        }).render('#paypal-button-container');
-    </script>
-
+  <h1>جارٍ تحويلك إلى بوابة الدفع…</h1>
+  <script type="module">
+    import { PAY_LINK_CARD, PAY_LINK_APPLE } from './assets/js/config.js';
+    const p = new URLSearchParams(location.search);
+    const email = p.get('email');
+    const udid = p.get('udid');
+    const token = p.get('token');
+    const method = p.get('method');
+    if(token){ localStorage.setItem('token', token); }
+    const base = method === 'apple' ? PAY_LINK_APPLE : PAY_LINK_CARD;
+    const url = new URL(base);
+    if(email) url.searchParams.set('email', email);
+    if(udid) url.searchParams.set('udid', udid);
+    location.replace(url);
+  </script>
 </body>
 </html>

--- a/success.html
+++ b/success.html
@@ -1,13 +1,22 @@
 <!doctype html><html lang="ar"><meta charset="utf-8">
 <title>تم — Xlop</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<body style="font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;max-width:680px;margin:40px auto;padding:0 16px;line-height:1.7">
-  <h1>تم استقبال البيانات ✅</h1>
+<body style="font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;max-width:680px;margin:40px auto;padding:0 16px;line-height:1.7;text-align:center">
+  <h1>تم الدفع بنجاح ✅</h1>
   <p>إن وجد <code>UDID</code> سيتم عرضه بالأسفل.</p>
   <div id="udid" style="padding:12px 16px;border:1px solid #ddd;border-radius:8px"></div>
+  <p><a id="install" href="#" style="display:none;margin-top:24px;padding:12px 18px;border-radius:10px;background:#000;color:#fff;text-decoration:none;font-weight:600">متابعة التثبيت</a></p>
   <script>
     const p = new URLSearchParams(location.search);
-    const u = p.get('udid');
-    document.getElementById('udid').textContent = u ? u : 'لا يوجد UDID في الرابط.';
+    const email = p.get('email');
+    const udid = p.get('udid');
+    const token = p.get('token') || localStorage.getItem('token');
+    document.getElementById('udid').textContent = udid ? udid : 'لا يوجد UDID في الرابط.';
+    if (email && udid && token) {
+      const params = new URLSearchParams({ email, udid, token });
+      const btn = document.getElementById('install');
+      btn.href = `install.html?${params.toString()}`;
+      btn.style.display = 'inline-block';
+    }
   </script>
 </body></html>


### PR DESCRIPTION
## Summary
- Redirect purchase page to Paymob based on method and keep email & UDID.
- Show "Continue installation" button after payment with email, UDID, and token.

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68ab2cdf38748324b90af21f611c31cb