### PR TITLE
feat: add install page for certificate setup

### DIFF
--- a/install.html
+++ b/install.html
@@ -1,0 +1,20 @@
+<!doctype html><html lang="ar"><meta charset="utf-8">
+<title>بدء التثبيت – Xlop</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<body style="font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;max-width:680px;margin:40px auto;padding:0 16px;line-height:1.7;text-align:center">
+  <h1>جارٍ بدء التثبيت…</h1>
+  <p>سيتم تحويلك للتثبيت تلقائيًا، وإن لم يحدث اضغط الزر بالأسفل.</p>
+  <p><a id="install" href="#" style="display:inline-block;margin-top:24px;padding:12px 18px;border-radius:10px;background:#000;color:#fff;text-decoration:none;font-weight:600">ابدأ التثبيت</a></p>
+  <script type="module">
+    import { FRONT_URL, gboxLink } from './assets/js/config.js';
+    const p = new URLSearchParams(location.search);
+    const udid = p.get('udid');
+    const token = p.get('token') || localStorage.getItem('token');
+    const email = p.get('email');
+    if (token) { localStorage.setItem('token', token); }
+    const url = gboxLink({ udid, token, redirect: FRONT_URL + '/success.html' });
+    const btn = document.getElementById('install');
+    btn.href = url;
+    try { location.replace(url); } catch (e) {}
+  </script>
+</body></html>


### PR DESCRIPTION
## Summary
- add install.html to generate gbox install link and auto-redirect
- include manual fallback button for starting installation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2dd46cd08324833fc9237ef10366