### PR TITLE
feat: add failure page and enhance success summary

### DIFF
--- a/fail.html
+++ b/fail.html
@@ -1,28 +1,20 @@
 <!doctype html><html lang="ar"><meta charset="utf-8">
-<title>تم — Xlop</title>
+<title>فشل العملية — Xlop</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <body style="font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;max-width:680px;margin:40px auto;padding:0 16px;line-height:1.7;text-align:center">
-  <h1>تم الدفع بنجاح ✅</h1>
-  <p>ملخص بيانات الطلب:</p>
+  <h1>لم تكتمل العملية ❌</h1>
+  <p>حدث خطأ أثناء الدفع أو تم إلغاء العملية.</p>
   <div id="summary" style="padding:12px 16px;border:1px solid #ddd;border-radius:8px">
     <div>البريد الإلكتروني: <strong id="email">—</strong></div>
     <div>UDID: <strong id="udid">—</strong></div>
   </div>
-  <p><a id="install" href="#" style="display:none;margin-top:24px;padding:12px 18px;border-radius:10px;background:#000;color:#fff;text-decoration:none;font-weight:600">متابعة التثبيت</a></p>
   <p style="margin-top:24px">للدعم تواصل عبر <a href="https://wa.me/1234567890" target="_blank">واتساب</a> أو <a href="https://t.me/xlop_support" target="_blank">تليجرام</a>.</p>
   <p><a href="index.html" style="display:inline-block;margin-top:8px;padding:12px 18px;border-radius:10px;border:1px solid #000;color:#000;text-decoration:none;font-weight:600">العودة للرئيسية</a></p>
   <script>
     const p = new URLSearchParams(location.search);
     const email = p.get('email');
     const udid = p.get('udid');
-    const token = p.get('token') || localStorage.getItem('token');
     document.getElementById('email').textContent = email ? email : 'غير متوفر';
     document.getElementById('udid').textContent = udid ? udid : 'غير متوفر';
-    if (email && udid && token) {
-      const params = new URLSearchParams({ email, udid, token });
-      const btn = document.getElementById('install');
-      btn.href = `install.html?${params.toString()}`;
-      btn.style.display = 'inline-block';
-    }
   </script>
 </body></html>


### PR DESCRIPTION
## Summary
- show email/UDID summary and support links on success page
- add fail page with matching layout and support contacts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2edfeb548324a82feb8ebfdfc5b6