### PR TITLE
Add RTL support and centralize styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -7,10 +7,19 @@
   --border:#1f1f23;
 }
 *{box-sizing:border-box}
-html,body{margin:0;padding:0;background:var(--bg);color:var(--fg);font:16px/1.6 -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Inter,Arial,sans-serif}
+html,body{
+  margin:0;
+  padding:0;
+  background:var(--bg);
+  color:var(--fg);
+  font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Inter,Arial,sans-serif;
+  font-size:16px;
+  line-height:1.7;
+  direction:rtl;
+}
 .container{max-width:1100px;margin:0 auto;padding:0 16px}
 .nav{display:flex;align-items:center;justify-content:space-between;padding:18px 0;border-bottom:1px solid var(--border);position:sticky;top:0;background:rgba(11,11,12,.85);backdrop-filter: blur(8px);}
-.nav a{color:var(--fg);text-decoration:none;margin-left:16px}
+.nav a{color:var(--fg);text-decoration:none;margin-inline-start:16px}
 .brand{display:flex;align-items:center;gap:10px}
 .brand img{height:28px}
 .btn{display:inline-block;padding:12px 18px;border-radius:10px;background:#fff;color:#000;text-decoration:none;font-weight:600}
@@ -28,7 +37,21 @@ html,body{margin:0;padding:0;background:var(--bg);color:var(--fg);font:16px/1.6 
 label{display:block;margin:10px 0 6px}
 .section{padding:40px 0}
 kbd{background:#222;padding:2px 6px;border-radius:6px;border:1px solid #333}
-.success{padding:80px 0;text-align:center}
+.success-page{padding:80px 0;text-align:center}
 .badge{display:inline-block;background:#0ea5e9;color:#001;padding:4px 8px;border-radius:999px;font-weight:700;font-size:12px;margin-bottom:10px}
 .warning{color:#fbbf24}
 a{color:#7dd3fc}
+/* utilities */
+.actions{display:flex;gap:12px;justify-content:center;margin-top:12px}
+#quick-form{max-width:400px;margin:auto}
+#quick-form .btn{margin-top:12px}
+#udidStatus{display:none}
+.page{max-width:680px;margin:40px auto;padding:0 16px;text-align:center}
+.summary{padding:12px 16px;border:1px solid var(--border);border-radius:8px}
+.mt-8{margin-top:8px}
+.mt-12{margin-top:12px}
+.mt-24{margin-top:24px}
+.hidden{display:none}
+.message{padding:12px 16px;border-radius:10px;margin:12px 0;text-align:center}
+.message.success{background:#16a34a;color:#fff}
+.message.error{background:#dc2626;color:#fff}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -16,7 +16,8 @@ import { BACKEND_URL } from './config.js';
     const got=document.querySelector('#udidStatus');
     if(got){
       got.textContent='تم جلب UDID تلقائيًا ✅';
-      got.style.display='block';
+      got.classList.remove('hidden');
+      got.classList.add('message','success');
     }
   }
   // Smooth scroll for anchors

--- a/fail.html
+++ b/fail.html
@@ -1,15 +1,23 @@
-<!doctype html><html lang="ar"><meta charset="utf-8">
-<title>فشل العملية — Xlop</title>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<body style="font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;max-width:680px;margin:40px auto;padding:0 16px;line-height:1.7;text-align:center">
+<!doctype html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>فشل العملية — Xlop</title>
+  <meta name="description" content="حدث خطأ أثناء الدفع أو تم إلغاء العملية.">
+  <link rel="icon" href="assets/logo.svg">
+  <meta name="theme-color" content="#0b0b0c">
+  <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body class="page">
   <h1>لم تكتمل العملية ❌</h1>
   <p>حدث خطأ أثناء الدفع أو تم إلغاء العملية.</p>
-  <div id="summary" style="padding:12px 16px;border:1px solid #ddd;border-radius:8px">
+  <div id="summary" class="summary">
     <div>البريد الإلكتروني: <strong id="email">—</strong></div>
     <div>UDID: <strong id="udid">—</strong></div>
   </div>
-  <p style="margin-top:24px">للدعم تواصل عبر <a href="https://wa.me/1234567890" target="_blank">واتساب</a> أو <a href="https://t.me/xlop_support" target="_blank">تليجرام</a>.</p>
-  <p><a href="index.html" style="display:inline-block;margin-top:8px;padding:12px 18px;border-radius:10px;border:1px solid #000;color:#000;text-decoration:none;font-weight:600">العودة للرئيسية</a></p>
+  <p class="mt-24">للدعم تواصل عبر <a href="https://wa.me/1234567890" target="_blank">واتساب</a> أو <a href="https://t.me/xlop_support" target="_blank">تليجرام</a>.</p>
+  <p><a href="index.html" class="btn outline mt-8">العودة للرئيسية</a></p>
   <script>
     const p = new URLSearchParams(location.search);
     const email = p.get('email');
@@ -17,4 +25,5 @@
     document.getElementById('email').textContent = email ? email : 'غير متوفر';
     document.getElementById('udid').textContent = udid ? udid : 'غير متوفر';
   </script>
-</body></html>
+</body>
+</html>

--- a/faq.html
+++ b/faq.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>الأسئلة الشائعة – Xlop</title>
+  <meta name="description" content="إجابات عن أكثر الأسئلة حول شهادات توقيع iOS من Xlop.">
+  <link rel="icon" href="assets/logo.svg">
+  <meta name="theme-color" content="#0b0b0c">
   <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -4,9 +4,11 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Xlop Certificates</title>
-    <link rel="stylesheet" href="assets/css/style.css">
-    <script type="module" src="assets/js/main.js"></script>
   <meta name="description" content="شهادات توقيع iOS مع جلب UDID تلقائياً.">
+  <link rel="icon" href="assets/logo.svg">
+  <meta name="theme-color" content="#0b0b0c">
+  <link rel="stylesheet" href="assets/css/style.css">
+  <script type="module" src="assets/js/main.js"></script>
 </head>
 <body>
   <nav class="nav container">
@@ -25,17 +27,17 @@
     <div class="badge">يدعم جلب الـ UDID تلقائيًا</div>
     <h1>شهادات توقيع iOS — بسرعة وثقة</h1>
     <p>اضغط زر <strong>الحصول على UDID</strong> لتنزيل ملف تعريف مؤقت، ثبّته من الإعدادات، وبنرجّعك للصفحة ورقم جهازك جاهز تلقائيًا.</p>
-    <div style="display:flex;gap:12px;justify-content:center;margin-top:12px">
+    <div class="actions">
       <a class="btn" id="get-udid" href="#">الحصول على UDID</a>
       <a class="btn outline" href="purchase.html">شراء الشهادة</a>
     </div>
     <p class="note">يُفضل فتح الموقع عبر Safari على iPhone.</p>
-    <p id="udidStatus" class="note" style="display:none"></p>
+    <p id="udidStatus" class="note hidden"></p>
   </header>
 
   <section class="section container">
     <h2>شراء سريع</h2>
-    <form id="quick-form" dir="rtl" style="max-width:400px;margin:auto">
+    <form id="quick-form" dir="rtl">
       <label for="email">البريد الإلكتروني</label>
       <input class="input" type="email" id="email" required>
       <label for="udid">UDID</label>
@@ -47,7 +49,7 @@
         <option value="card">بطاقة</option>
         <option value="apple">Apple</option>
       </select>
-      <button type="submit" class="btn" style="margin-top:12px">ادفع الآن</button>
+      <button type="submit" class="btn mt-12">ادفع الآن</button>
     </form>
   </section>
 

--- a/install.html
+++ b/install.html
@@ -1,10 +1,18 @@
-<!doctype html><html lang="ar"><meta charset="utf-8">
-<title>بدء التثبيت – Xlop</title>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<body style="font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;max-width:680px;margin:40px auto;padding:0 16px;line-height:1.7;text-align:center">
+<!doctype html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>بدء التثبيت – Xlop</title>
+  <meta name="description" content="بدء تثبيت الشهادة على جهازك.">
+  <link rel="icon" href="assets/logo.svg">
+  <meta name="theme-color" content="#0b0b0c">
+  <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body class="page">
   <h1>جارٍ بدء التثبيت…</h1>
   <p>سيتم تحويلك للتثبيت تلقائيًا، وإن لم يحدث اضغط الزر بالأسفل.</p>
-  <p><a id="install" href="#" style="display:inline-block;margin-top:24px;padding:12px 18px;border-radius:10px;background:#000;color:#fff;text-decoration:none;font-weight:600">ابدأ التثبيت</a></p>
+  <p><a id="install" class="btn mt-24" href="#">ابدأ التثبيت</a></p>
   <script type="module">
     import { FRONT_URL, gboxLink } from './assets/js/config.js';
     const p = new URLSearchParams(location.search);
@@ -17,4 +25,5 @@
     btn.href = url;
     try { location.replace(url); } catch (e) {}
   </script>
-</body></html>
+</body>
+</html>

--- a/purchase.html
+++ b/purchase.html
@@ -4,11 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>جارٍ تحويلك…</title>
-  <style>
-    body{background:#000;color:#fff;font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;text-align:center;padding:40px}
-  </style>
+  <meta name="description" content="تحويل آمن إلى بوابة الدفع لشهادات Xlop.">
+  <link rel="icon" href="assets/logo.svg">
+  <meta name="theme-color" content="#0b0b0c">
+  <link rel="stylesheet" href="assets/css/style.css">
 </head>
-<body>
+<body class="page">
   <h1>جارٍ تحويلك إلى بوابة الدفع…</h1>
   <script type="module">
     import { PAY_LINK_CARD, PAY_LINK_APPLE } from './assets/js/config.js';

--- a/success.html
+++ b/success.html
@@ -1,16 +1,24 @@
-<!doctype html><html lang="ar"><meta charset="utf-8">
-<title>تم — Xlop</title>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<body style="font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;max-width:680px;margin:40px auto;padding:0 16px;line-height:1.7;text-align:center">
+<!doctype html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>تم — Xlop</title>
+  <meta name="description" content="تم الدفع بنجاح ويمكنك متابعة تثبيت الشهادة.">
+  <link rel="icon" href="assets/logo.svg">
+  <meta name="theme-color" content="#0b0b0c">
+  <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body class="page success-page">
   <h1>تم الدفع بنجاح ✅</h1>
   <p>ملخص بيانات الطلب:</p>
-  <div id="summary" style="padding:12px 16px;border:1px solid #ddd;border-radius:8px">
+  <div id="summary" class="summary">
     <div>البريد الإلكتروني: <strong id="email">—</strong></div>
     <div>UDID: <strong id="udid">—</strong></div>
   </div>
-  <p><a id="install" href="#" style="display:none;margin-top:24px;padding:12px 18px;border-radius:10px;background:#000;color:#fff;text-decoration:none;font-weight:600">متابعة التثبيت</a></p>
-  <p style="margin-top:24px">للدعم تواصل عبر <a href="https://wa.me/1234567890" target="_blank">واتساب</a> أو <a href="https://t.me/xlop_support" target="_blank">تليجرام</a>.</p>
-  <p><a href="index.html" style="display:inline-block;margin-top:8px;padding:12px 18px;border-radius:10px;border:1px solid #000;color:#000;text-decoration:none;font-weight:600">العودة للرئيسية</a></p>
+  <p><a id="install" class="btn hidden mt-24" href="#">متابعة التثبيت</a></p>
+  <p class="mt-24">للدعم تواصل عبر <a href="https://wa.me/1234567890" target="_blank">واتساب</a> أو <a href="https://t.me/xlop_support" target="_blank">تليجرام</a>.</p>
+  <p><a href="index.html" class="btn outline mt-8">العودة للرئيسية</a></p>
   <script>
     const p = new URLSearchParams(location.search);
     const email = p.get('email');
@@ -22,7 +30,8 @@
       const params = new URLSearchParams({ email, udid, token });
       const btn = document.getElementById('install');
       btn.href = `install.html?${params.toString()}`;
-      btn.style.display = 'inline-block';
+      btn.classList.remove('hidden');
     }
   </script>
-</body></html>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- centralize layout and utility rules in `style.css` and enable RTL defaults
- add global meta tags, favicon, and shared stylesheet links across pages
- style success/error messages and update script to apply them

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2f9c81d883249383b5ebdf0ec960