### PR TITLE
feat: add health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,7 @@ curl -X POST "PHP_BASE_URL/get-udid.php" \
   --data-binary '<plist><dict><key>UDID</key><string>TEST-UDID-123</string></dict></plist>' -i
 ```
 يجب أن يرجع 302 إلى `FRONT_URL/success.html?udid=TEST-UDID-123`.
+
+## Health Check
+
+بعد نشر التطبيق يمكنك التأكد من أنه يعمل عن طريق زيارة المسار `/health`، والذي يعيد النص `ok`.

--- a/server.js
+++ b/server.js
@@ -97,6 +97,10 @@ app.post('/paymob/webhook', (req, res) => {
   return res.sendStatus(401);
 });
 
+app.get('/health', (req, res) => {
+  res.send('ok');
+});
+
 const PORT = process.env.PORT || 8080;
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);


### PR DESCRIPTION
## Summary
- add simple GET /health endpoint
- document health check usage

## Testing
- `npm test`
- `npm install --no-save --no-package-lock` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4ddbd9748324998dd4a8dabd980b