### PR TITLE
Validate UDID input and add client-side normalization

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -47,8 +47,9 @@ import { BACKEND_URL } from './config.js';
       email.setCustomValidity(/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)?'':'البريد غير صحيح');
     };
     const validateUdid=()=>{
-      const v=udidInput.value.trim();
-      udidInput.setCustomValidity(v.startsWith('000') && v.length===40 ? '' : 'رقم UDID غير صالح');
+      const v=udidInput.value.trim().replace(/[^a-fA-F0-9]/g,'').toUpperCase();
+      udidInput.value=v;
+      udidInput.setCustomValidity(/^[A-F0-9]{24,40}$/.test(v)?'' : 'رقم UDID غير صالح');
     };
     const validateToken=()=>{
       const v=token.value.trim();

--- a/index.html
+++ b/index.html
@@ -45,7 +45,10 @@
       <label for="email">البريد الإلكتروني</label>
       <input class="input" type="email" id="email" required>
       <label for="udid">رقم UDID</label>
-      <input class="input" type="text" id="udid" required>
+      <input class="input" type="text" id="udid" name="udid" required
+        inputmode="latin" autocomplete="off" autocapitalize="off" spellcheck="false" dir="ltr"
+        placeholder="مثال: 00008101XXXXXXXXXXXXXXXXXXXXXXX0000"
+        pattern="[A-Fa-f0-9]{24,40}">
       <label for="token">الرمز</label>
       <input class="input" type="text" id="token" required>
       <label for="method">طريقة الدفع</label>
@@ -53,7 +56,33 @@
         <option value="card">بطاقة</option>
         <option value="apple">Apple</option>
       </select>
-      <button type="submit" class="btn mt-12">ادفع الآن</button>
+      <script>
+      function normalizeUDID(val){
+        // احذف أي شيء غير سداسي عشري
+        return (val || '').replace(/[^a-fA-F0-9]/g,'').toUpperCase();
+      }
+
+      function isValidUDID(val){
+        const v = normalizeUDID(val);
+        // اقبل 24 إلى 40 حرفًا سداسيًا
+        return /^[A-F0-9]{24,40}$/.test(v);
+      }
+
+      document.getElementById('pay-btn')?.addEventListener('click', function(e){
+        const input = document.getElementById('udid');
+        const cleaned = normalizeUDID(input.value);
+        input.value = cleaned; // خزّن المنظّف
+
+        if(!isValidUDID(cleaned)){
+          e.preventDefault();
+          alert('رقم UDID غير صالح — استخدم حروف/أرقام إنجليزية فقط، بدون مسافات، بطول 24–40.');
+          input.focus();
+          return false;
+        }
+        // أكمل الدفع هنا...
+      });
+      </script>
+      <button type="submit" class="btn mt-12" id="pay-btn">ادفع الآن</button>
     </form>
   </section>
 


### PR DESCRIPTION
## Summary
- enforce UDID field to accept 24-40 hex characters only
- normalize and validate UDID on payment click
- align quick-form validation to new UDID rules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab5480ed7c8324b8bc122591608a45