### PR TITLE
Show failure reason in debugging output

### DIFF
--- a/fail.html
+++ b/fail.html
@@ -28,6 +28,14 @@
     const udid = p.get('udid');
     document.getElementById('email').textContent = email ? email : 'غير متوفر';
     document.getElementById('udid').textContent = udid ? udid : 'غير متوفر';
+    const reasonParam = p.get('reason');
+    if (reasonParam) {
+      // Temporary debug output for failure reason
+      const pre = document.createElement('pre');
+      pre.textContent = decodeURIComponent(reasonParam);
+      pre.style.whiteSpace = 'pre-wrap';
+      document.body.appendChild(pre);
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- parse `reason` query param on the failure page
- decode and render the reason inside a `<pre>` block for easier reading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab5af6ca0883249dbc3246d893b756