### PR TITLE
Handle Paymob redirects on backend

### DIFF
--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -1,7 +1,7 @@
 export const FRONT_URL = 'https://mimo050.github.io/xlop-cert-site';
 export const BACKEND_URL = 'https://xlop-cert-site.onrender.com';
-export const PAY_LINK_CARD = '';
-export const PAY_LINK_APPLE = '';
+export const PAY_LINK_CARD = `${BACKEND_URL}/pay/card`;
+export const PAY_LINK_APPLE = `${BACKEND_URL}/pay/apple`;
 export const GBOX_BASE = '';
 
 export function gboxLink({ udid, token, redirect }) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,4 @@
-import { BACKEND_URL } from './config.js';
+import { BACKEND_URL, PAY_LINK_CARD, PAY_LINK_APPLE } from './config.js';
 
 (function(){
   // Set backend link for UDID profile
@@ -61,64 +61,25 @@ import { BACKEND_URL } from './config.js';
     token.addEventListener('input', ()=>{ validateToken(); localStorage.setItem('token', token.value); });
     method.addEventListener('change', ()=>{ localStorage.setItem('method', method.value); });
 
-    form.addEventListener('submit', async e=>{
-      e.preventDefault();
+    form.addEventListener('submit', e=>{
       validateEmail();
       validateUdid();
       validateToken();
-      if(form.checkValidity()){
-        const emailVal=email.value.trim();
-        const udidVal=udidInput.value.trim();
-        const methodVal=method.value;
-        localStorage.setItem('email', emailVal);
-        localStorage.setItem('udid', udidVal);
-        localStorage.setItem('token', token.value);
-        localStorage.setItem('method', methodVal);
-        try{
-          const res=await fetch(`${BACKEND_URL}/paymob/create`,{
-            method:'POST',
-            headers:{'Content-Type':'application/json'},
-            body:JSON.stringify({email:emailVal, udid:udidVal, method:methodVal})
-          });
-          const data=await res.json();
-          if(data.iframeUrl){
-            const overlay=document.createElement('div');
-            overlay.style.position='fixed';
-            overlay.style.inset='0';
-            overlay.style.background='rgba(0,0,0,0.8)';
-            overlay.style.display='flex';
-            overlay.style.alignItems='center';
-            overlay.style.justifyContent='center';
-            const box=document.createElement('div');
-            box.style.width='100%';
-            box.style.maxWidth='480px';
-            box.style.background='#fff';
-            box.style.borderRadius='8px';
-            box.style.padding='16px';
-            const iframe=document.createElement('iframe');
-            iframe.src=data.iframeUrl;
-            iframe.style.width='100%';
-            iframe.style.height='400px';
-            iframe.style.border='0';
-            const btn=document.createElement('button');
-            btn.textContent='إكمال الطلب';
-            btn.className='btn mt-12';
-            btn.addEventListener('click',()=>{
-              location.href=`success.html?email=${encodeURIComponent(emailVal)}&udid=${encodeURIComponent(udidVal)}`;
-            });
-            box.appendChild(iframe);
-            box.appendChild(btn);
-            overlay.appendChild(box);
-            document.body.appendChild(overlay);
-          }else{
-            location.href=`fail.html?email=${encodeURIComponent(emailVal)}&udid=${encodeURIComponent(udidVal)}`;
-          }
-        }catch(err){
-          location.href=`fail.html?email=${encodeURIComponent(emailVal)}&udid=${encodeURIComponent(udidVal)}`;
-        }
-      }else{
+      if(!form.checkValidity()){
+        e.preventDefault();
         form.reportValidity();
+        return;
       }
+      const emailVal=email.value.trim();
+      const udidVal=udidInput.value.trim();
+      const tokenVal=token.value.trim();
+      const methodVal=method.value;
+      localStorage.setItem('email', emailVal);
+      localStorage.setItem('udid', udidVal);
+      localStorage.setItem('token', tokenVal);
+      localStorage.setItem('method', methodVal);
+      const action=methodVal==='apple'?PAY_LINK_APPLE:PAY_LINK_CARD;
+      form.action=action;
     });
   }
 })();

--- a/index.html
+++ b/index.html
@@ -43,19 +43,20 @@
     <h2>شراء سريع</h2>
     <form id="quick-form" dir="rtl">
       <label for="email">البريد الإلكتروني</label>
-      <input class="input" type="email" id="email" required>
+      <input class="input" type="email" id="email" name="email" required>
       <label for="udid">رقم UDID</label>
       <input class="input" type="text" id="udid" name="udid" required
         inputmode="latin" autocomplete="off" autocapitalize="off" spellcheck="false" dir="ltr"
         placeholder="مثال: 00008101XXXXXXXXXXXXXXXXXXXXXXX0000"
         pattern="[A-Fa-f0-9]{24,40}">
       <label for="token">الرمز</label>
-      <input class="input" type="text" id="token" required>
+      <input class="input" type="text" id="token" name="token" required>
       <label for="method">طريقة الدفع</label>
-      <select class="input" id="method">
+      <select class="input" id="method" name="method">
         <option value="card">بطاقة</option>
         <option value="apple">Apple</option>
       </select>
+      <input type="hidden" id="amount" name="amount" value="59">
       <script>
       function normalizeUDID(val){
         // احذف أي شيء غير سداسي عشري


### PR DESCRIPTION
## Summary
- Replace fetch-based payment overlay with direct form navigation to backend `/pay` routes
- Append email, UDID, and token to iframe requests and forward Paymob redirects to `SUCCESS_URL` or `FAIL_URL`

## Testing
- `npm test`
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab5b8b19f08324b172c88bddb71c99