### PR TITLE
Drop dynamic payment link selection from quick form

### DIFF
--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -1,7 +1,5 @@
 export const FRONT_URL = 'https://mimo050.github.io/xlop-cert-site';
 export const BACKEND_URL = 'https://xlop-cert-site.onrender.com';
-export const PAY_LINK_CARD = `${BACKEND_URL}/pay/card`;
-export const PAY_LINK_APPLE = `${BACKEND_URL}/pay/apple`;
 export const GBOX_BASE = '';
 
 export function gboxLink({ udid, token, redirect }) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,4 @@
-import { BACKEND_URL, PAY_LINK_CARD, PAY_LINK_APPLE } from './config.js';
+import { BACKEND_URL } from './config.js';
 
 (function(){
   // Set backend link for UDID profile
@@ -78,8 +78,7 @@ import { BACKEND_URL, PAY_LINK_CARD, PAY_LINK_APPLE } from './config.js';
       localStorage.setItem('udid', udidVal);
       localStorage.setItem('token', tokenVal);
       localStorage.setItem('method', methodVal);
-      const action=methodVal==='apple'?PAY_LINK_APPLE:PAY_LINK_CARD;
-      form.action=action;
+      // form.action will rely on static HTML configuration
     });
   }
 })();


### PR DESCRIPTION
## Summary
- stop importing unused payment link constants
- rely on static HTML action/method instead of dynamic form.action assignment
- drop unused pay link URLs from config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab60d9c1e483248de44614114b8d54