### PR TITLE
Add basic Express backend for payment redirect

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "Simple express backend for payment redirect",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "test": "node -e \"console.log('No tests')\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.0"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,17 @@
+const express = require('express');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Redirects to provided iframe URL
+app.get('/pay/card', (req, res) => {
+  const iframeUrl = req.query.iframe;
+  if (!iframeUrl) {
+    return res.status(400).send('Missing iframe query parameter');
+  }
+  res.redirect(iframeUrl);
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a Node.js backend with Express
- implement `/pay/card` redirect handler

## Testing
- `npm install --fetch-retries=0` *(fails: ENETUNREACH)*
- `npm test` (backend)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab66bf40888324953d34f965d6faf7