### PR TITLE
Hide failure reason and log on server

### DIFF
--- a/fail.html
+++ b/fail.html
@@ -22,7 +22,9 @@
   </div>
   <p class="mt-24">للدعم تواصل عبر <a href="https://wa.me/1234567890" target="_blank">واتساب</a> أو <a href="https://t.me/xlop_support" target="_blank">تليجرام</a>.</p>
   <p><a href="index.html" class="btn outline mt-8">العودة للرئيسية</a></p>
-  <script>
+  <script type="module">
+    import { BACKEND_URL } from './assets/js/config.js';
+
     const p = new URLSearchParams(location.search);
     const email = p.get('email');
     const udid = p.get('udid');
@@ -30,11 +32,14 @@
     document.getElementById('udid').textContent = udid ? udid : 'غير متوفر';
     const reasonParam = p.get('reason');
     if (reasonParam) {
-      // Temporary debug output for failure reason
-      const pre = document.createElement('pre');
-      pre.textContent = decodeURIComponent(reasonParam);
-      pre.style.whiteSpace = 'pre-wrap';
-      document.body.appendChild(pre);
+      const msg = document.createElement('p');
+      msg.textContent = 'حدث خلل غير متوقع وتم تسجيله للمراجعة.';
+      document.body.appendChild(msg);
+      fetch(`${BACKEND_URL}/log-failure`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, udid, reason: decodeURIComponent(reasonParam) }),
+      }).catch(() => {});
     }
   </script>
 </body>

--- a/server.js
+++ b/server.js
@@ -112,6 +112,7 @@ async function pay(req, res, integrationId) {
     res.redirect(iframe);
   } catch (err) {
     const reason = err.response?.data?.message || err.message;
+    console.error('Payment failed:', reason);
     res.redirect(appendQuery(FAIL_URL, { ...req.body, reason }));
   }
 }
@@ -126,6 +127,11 @@ function forward(url) {
 
 app.get('/pay/success', forward(SUCCESS_URL));
 app.get('/pay/fail', forward(FAIL_URL));
+
+app.post('/log-failure', (req, res) => {
+  console.error('Client failure reported:', req.body);
+  res.sendStatus(200);
+});
 
 app.post('/webhook', (req, res) => {
   console.log('Webhook received', req.body);


### PR DESCRIPTION
## Summary
- Stop exposing detailed failure reasons in `fail.html` and send them to the backend for logging
- Log payment errors on the server and add `/log-failure` endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab6a536c108324857df2627196d06a