### PR TITLE
Validate iframe URL before redirecting

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -3,11 +3,20 @@ const express = require('express');
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+// List of allowed iframe URL patterns
+const ALLOWED_IFRAME_PATTERNS = [
+  /^https:\/\/[^/]*paymob\.com\/acceptance\/iframes\//,
+];
+
 // Redirects to provided iframe URL
 app.get('/pay/card', (req, res) => {
   const iframeUrl = req.query.iframe;
   if (!iframeUrl) {
     return res.status(400).send('Missing iframe query parameter');
+  }
+  const isAllowed = ALLOWED_IFRAME_PATTERNS.some(pattern => pattern.test(iframeUrl));
+  if (!isAllowed) {
+    return res.status(400).send('Invalid iframe URL');
   }
   res.redirect(iframeUrl);
 });


### PR DESCRIPTION
## Summary
- ensure `/pay/card` only redirects to allowed Paymob iframe URLs
- return 400 error when iframe URL does not match allowed pattern

## Testing
- `npm test`
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab6b1e6220832485e0187e9c3301cc