### PR TITLE
Log payment errors server-side

### DIFF
--- a/server.js
+++ b/server.js
@@ -130,9 +130,8 @@ async function pay(req, res, integrationId) {
     const iframe = `${PAYMOB_BASE}/acceptance/iframes/${PAYMOB_IFRAME_ID}?payment_token=${paymentToken}${extra.toString() ? `&${extra}` : ''}`;
     res.redirect(iframe);
   } catch (err) {
-    const reason = err.response?.data?.message || err.message;
-    console.error('Payment failed:', reason);
-    res.redirect(appendQuery(FAIL_URL, { ...req.body, reason }));
+    console.error('Payment failed:', err.response?.data || err.message);
+    res.redirect(appendQuery(FAIL_URL, { ...req.body, reason: 'payment_failed' }));
   }
 }
 


### PR DESCRIPTION
## Summary
- Log full payment error details on the server
- Always redirect with a generic `payment_failed` reason for clients

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab6c4ea20083249706cda5dba7c3b4