### PR TITLE
Handle missing GBOX base URL

### DIFF
--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -3,9 +3,15 @@ export const BACKEND_URL = 'https://xlop-cert-site.onrender.com';
 export const GBOX_BASE = '';
 
 export function gboxLink({ udid, token, redirect }) {
+  if (!GBOX_BASE) {
+    console.error('GBOX_BASE is not configured');
+    return '#';
+  }
+
   const params = new URLSearchParams();
   if (udid) params.set('udid', udid);
   if (token) params.set('token', token);
   if (redirect) params.set('redirect', redirect);
+
   return `${GBOX_BASE}?${params.toString()}`;
 }


### PR DESCRIPTION
## Summary
- avoid constructing gbox links when `GBOX_BASE` is empty
- return a safe placeholder URL and log an error when base is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab6d54863c8324a68ca08ea9fd4651