### PR TITLE
Use sessionStorage for token instead of localStorage

### DIFF
--- a/install.html
+++ b/install.html
@@ -21,9 +21,9 @@
     import { FRONT_URL, gboxLink } from './assets/js/config.js';
     const p = new URLSearchParams(location.search);
     const udid = p.get('udid');
-    const token = p.get('token') || localStorage.getItem('token');
+    const token = p.get('token') || sessionStorage.getItem('token');
     const email = p.get('email');
-    if (token) { localStorage.setItem('token', token); }
+    if (token) { sessionStorage.setItem('token', token); }
     const url = gboxLink({ udid, token, redirect: FRONT_URL + '/success.html' });
     const btn = document.getElementById('install');
     btn.href = url;

--- a/success.html
+++ b/success.html
@@ -27,7 +27,7 @@
     const p = new URLSearchParams(location.search);
     const email = p.get('email');
     const udid = p.get('udid');
-    const token = p.get('token') || localStorage.getItem('token');
+    const token = p.get('token') || sessionStorage.getItem('token');
     document.getElementById('email').textContent = email ? email : 'غير متوفر';
     document.getElementById('udid').textContent = udid ? udid : 'غير متوفر';
     if (email && udid && token) {


### PR DESCRIPTION
## Summary
- Store installation token in sessionStorage rather than localStorage
- Load token from sessionStorage on success page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab74a977dc8324b3cf285162a7ff90