### PR TITLE
Validate positive amount input

### DIFF
--- a/server.js
+++ b/server.js
@@ -105,7 +105,8 @@ async function getPaymentKey(token, amountCents, orderId, integrationId, billing
 
 function computeAmountCents(amount) {
   const num = Number(amount);
-  if (!num || isNaN(num)) throw new Error('Invalid amount');
+  if (isNaN(num)) throw new Error('Invalid amount');
+  if (num <= 0) throw new Error('Amount must be positive');
   return Math.round(num * 100);
 }
 


### PR DESCRIPTION
## Summary
- ensure `computeAmountCents` rejects non-positive amounts with clear message

## Testing
- `npm test`
- `node --check server.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68ab75625d4083249b84d565e995435b