### PR TITLE
Restrict failure redirect data

### DIFF
--- a/server.js
+++ b/server.js
@@ -132,7 +132,8 @@ async function pay(req, res, integrationId) {
     res.redirect(iframe);
   } catch (err) {
     console.error('Payment failed:', err.response?.data || err.message);
-    res.redirect(appendQuery(FAIL_URL, { ...req.body, reason: 'payment_failed' }));
+    const { email, udid } = req.body;
+    res.redirect(appendQuery(FAIL_URL, { email, udid, reason: 'payment_failed' }));
   }
 }
 


### PR DESCRIPTION
## Summary
- Limit `/pay` failure redirects to include only `email` and `udid`
- Remove sensitive fields before constructing failure URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab768f28c88324a3149710f6e381f1