### PR TITLE
Show retrieved UDID on landing page

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -19,6 +19,8 @@ import { BACKEND_URL } from './config.js';
       got.classList.remove('hidden');
       got.classList.add('message','success');
     }
+    const udidDisplay=document.querySelector('#udidDisplay');
+    if(udidDisplay){ udidDisplay.textContent=udid; udidDisplay.classList.remove('hidden'); }
   }
   // Smooth scroll for anchors
   document.querySelectorAll('a[href^="#"]').forEach(a=>{

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
     </div>
     <p class="note">يُفضل فتح الموقع عبر Safari على iPhone.</p>
     <p id="udidStatus" class="note hidden"></p>
+    <p id="udidDisplay" class="note hidden"></p>
   </header>
 
 


### PR DESCRIPTION
## Summary
- Add a hidden paragraph to display retrieved UDID
- Populate and reveal UDID display when returning with UDID parameter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab7b2669fc8324adf520acadf1bc07