### PR TITLE
Signed mobileconfig (PKCS#7) + UDID flow hardening

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "express": "^4.19.2",
+    "node-forge": "^1.3.1",
     "xml2js": "^0.6.2"
   }
 }


### PR DESCRIPTION
## Summary
- sign mobileconfig files via PKCS#7 when SIGN_CERT_PEM/SIGN_KEY_PEM are provided
- fall back to unsigned mobileconfig if signing materials missing
- improve UDID extraction and redirect flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm i node-forge` *(fails: 403 Forbidden - GET https://registry.npmjs.org/node-forge)*

------
https://chatgpt.com/codex/tasks/task_e_68b454ccf1fc8324909f8336ee7bfd21