### PR TITLE
feat: add environment check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "type": "module",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test-env": "node testEnv.js"
   },
   "dependencies": {
     "express": "^4.19.2",

--- a/testEnv.js
+++ b/testEnv.js
@@ -1,0 +1,16 @@
+// testEnv.js
+console.log("=== Environment Variables Check ===");
+
+if (process.env.SIGN_CERT_PEM) {
+  console.log("✅ SIGN_CERT_PEM موجود");
+} else {
+  console.log("❌ SIGN_CERT_PEM غير موجود");
+}
+
+if (process.env.SIGN_KEY_PEM) {
+  console.log("✅ SIGN_KEY_PEM موجود");
+} else {
+  console.log("❌ SIGN_KEY_PEM غير موجود");
+}
+
+console.log("=== نهاية الفحص ===");


### PR DESCRIPTION
## Summary
- add `testEnv.js` script to verify presence of SIGN_CERT_PEM and SIGN_KEY_PEM
- expose `npm run test-env` for running the check

## Testing
- `npm run test-env`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b45d974704832480f3d9a061994394